### PR TITLE
Update charter based on F2F discussions during TPAC

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,43 +216,58 @@
             <p class="draft-status"> <b>Draft state:</b> <a href="http://www.w3.org/TR/2016/CR-presentation-api-20160714/">
                 CR</a> / Stable </p>
             <p class="milestone">
-              <b>Expected completion:</b> Q4 2019 &mdash; With the possible
-              exception of the testing API noted in <a href="#test-suite">Test
-              suite</a> below, this Working Group does not anticipate further
-              changes to this specification. That said, known implementation
-              plans are tied to the availability of the
-              <a href="https://github.com/webscreens/openscreenprotocol">Open
-              Screen Protocol</a>, under incubation in the
-              <a href="http://www.w3.org/community/webscreens/">Second Screen
-              Community Group</a>. The Working Group does not expect to be able
-              to meet the <a href="#success-criteria">Success Criteria</a> for
-              the Presentation API in the meantime. This Working Group plans to
-              assess progress on the suite of protocols at the end of this
-              Charter, and to request re-chartering accordingly to finalize the
+              <b>Expected completion:</b> Q4 2019 &mdash; This Working Group
+              does not anticipate further changes to this specification. The
+              Working Group is awaiting satisfaction of
+              the <a href="#success-criteria">Success Criteria</a>, which
+              require two interoperable implementations of the Presentation API.
+            </p>
+
+            <p>
+              The <a href="https://github.com/webscreens/openscreenprotocol">
+              Open Screen Protocol</a>, under incubation in
+              the <a href="http://www.w3.org/community/webscreens/"> Second
+              Screen Community Group</a>, is one proposed basis for
+              interoperability, and two implementations based on it would
+              satisfy those criteria. The charter timeline provides additional
+              time for interoperable implementations to be completed and the
+              Success Criteria to be met.
+            </p>
+
+            <p>
+              This Working Group plans to assess progress on interoperability
+              and implementation status regularly, and to request re-chartering
+              according to progress on meeting success criteria for the
               specification.
             </p>
           </dd>
-          <dt> Presentation API Level 2 </dt>
+          <dt id="level-2"> Presentation API Level 2 </dt>
           <dd>
             <p> A second version of the Presentation API that integrates
-              features which the Working Group resolved not to include in the
-              first version in the interest of time, feedback from Web
-              developers on the first version, as well as stable features
-              matured in the <a href="http://www.w3.org/community/webscreens/">Second
-                Screen Community Group</a>, provided they fall within the scope
-              of this Working Group. The Working Group's issue tracker lists <a
-                href="https://github.com/w3c/presentation-api/issues?q=label%3Av2">
-                examples of features</a> that may be integrated. </p>
-            <p class="draft-status"> <b>Draft state:</b> No draft (builds on
-              the CR) / Exploring </p>
-            <p class="milestone"> <b>Expected completion:</b> Progress on this
-              specification depends on the adoption of the first version of the
-              Presentation API and on the outcomes of discussions within the
-              companion <a href="http://www.w3.org/community/webscreens/">Second
-                Screen Community Group</a>. This Working Group does not expect
-              to complete this specification by the end of this charter and may
-              request to be re-chartered to finalize this work, possibly with a
-              different scope. </p>
+              features the Working Group resolved not to include in the first
+              version in the interest of time and feedback from Web developers
+              on the first version. New features that fall within the scope of
+              this Working Group may first be incubated and matured in an
+              appropriate Community Group.
+            </p>
+            <p>
+              The Working Group's issue tracker lists
+              <a href="https://github.com/w3c/presentation-api/issues?q=label%3Av2">
+              examples of features</a> that may be integrated.  An example of a
+              new feature is a
+              <a href="https://github.com/w3c/presentation-api/issues/440">Testing
+              API</a> that will allow automation of the
+              <a href="#test-suite">test suites</a> for the Presentation API and
+              Remote Playback API.
+            </p>
+            <p class="draft-status">
+              <b>Draft state:</b> No draft (builds on the CR) / Exploring
+            </p>
+            <p class="milestone"> <b>Expected completion:</b> This Working Group
+              does not expect to complete new specifications by the end of this
+              charter and may request to be re-chartered to finalize this work,
+              possibly with a different scope.
+            </p>
           </dd>
           <dt> <a href="http://www.w3.org/TR/remote-playback/">Remote Playback
               API</a> </dt>
@@ -263,15 +278,10 @@
             <p class="draft-status"> <b>Draft state:</b> <a href="http://www.w3.org/TR/2017/CR-remote-playback-20171019/">
                 CR</a> / Stable </p>
             <p class="milestone">
-              <b>Expected completion:</b> Q4 2018 &mdash; With the possible
-              exception of the testing API noted in <a href="#test-suite">Test
-              suite</a> below, this Working Group does not anticipate further
-              changes to this specification. As for the Presentation API,
-              progress on the
-              <a href="https://github.com/webscreens/openscreenprotocol">Open
-              Screen Protocol</a> will benefit this specification, but this
-              Working Group still expects to publish the Remote Playback API as
-              a final Recommendation in parallel to protocol discussions.
+              <b>Expected completion:</b> Q4 2018 &mdash; This Working Group
+              does not anticipate further changes to this specification. The
+              Working Group plans to publish the Remote Playback API as a final
+              Recommendation when the Success Criteria are met.
             </p>
           </dd>
         </dl>
@@ -280,23 +290,29 @@
         <h3 id="other-deliverables"> Other Deliverables </h3>
         <dl>
           <dt id="test-suite"> Test suite </dt>
-          <dd> A comprehensive test suite for all features of a specification is
-            necessary to assess the specification's robustness, consistency, and
-            implementability, and to promote interoperability between user
-            agents. Therefore, each specification must have a companion test
-            suite, which should be completed before transition to Candidate
-            Recommendation, and which must be completed with an implementation
-            report before transition to Proposed Recommendation. Additional
-            tests may be added to the test suite at any stage of the
-            Recommendation track, and the maintenance of an implementation
-            report is encouraged. </dd>
-          <dd> Additionally, this Working Group will seek to define a testing
-            API for the Presentation API and for the Remote Playback API
-            with a view to improve test automation, as well as to allow
-            developers to test their own web applications that make use of the
-            above-mentioned APIs. Depending on progress, this Working Group may
-            choose to include the testing APIs in the existing drafts, or to
-            define them in Level 2 versions of the specifications. </dd>
+          <dd>
+            <p>
+              A comprehensive test suite for all features of a specification is
+              necessary to assess the specification's robustness, consistency, and
+              implementability, and to promote interoperability between user
+              agents. Therefore, each specification must have a companion test
+              suite, which should be completed before transition to Candidate
+              Recommendation, and which must be completed with an implementation
+              report before transition to Proposed Recommendation. Additional
+              tests may be added to the test suite at any stage of the
+              Recommendation track, and the maintenance of an implementation
+              report is encouraged.
+            </p>
+            <p>
+              Additionally, this Working Group will improve test automation for
+              the Presentation API and Remote Playback API test suites. This
+              will be done through the adoption of a Testing API, developed as a
+              <a href="#level-2">Presentation API Level 2 specification</a>. The
+              Testing API will also allow developers to use automation to test
+              their own Web applications that make use of the above-mentioned
+              APIs.
+            </p>
+          </dd>
           <dt> Use cases and requirements </dt>
           <dd> The Working Group is strongly encouraging the participants to
             create and maintain a use cases and requirements document for each
@@ -363,7 +379,8 @@
       <div class="dependencies">
         <h2 id="coordination"> Dependencies and Liaisons </h2>
         <h3 id="dependencies"> Dependencies </h3>
-        <p> The initial draft of the Presentation API was prepared by the <a href="http://www.w3.org/community/webscreens/">Second
+        <p> The initial draft of the Presentation API was prepared by the
+          <a href="http://www.w3.org/community/webscreens/">Second
             Screen Community Group</a>. Upon approval of the Working Group, the
           Community Group ceased its work on the Presentation API
           specification. The Community Group is currently focused on incubating
@@ -373,7 +390,7 @@
           is not clear enough how to proceed for it to be a work item for a
           Working Group. The Community Group is only one possible source for
           work under future Working Group charters, but can serve to do initial
-        exploration for some future work items. </p>
+          exploration for some future work items. </p>
         <p> The specifications produced by this Working Group adhere to the
           web's security model defined in the HTML specification published by
           the Web Platform Working Group. </p>

--- a/index.html
+++ b/index.html
@@ -202,6 +202,12 @@
           the call for participation. Expected completion indicates when the
           deliverable is projected to become a Recommendation, or otherwise
           reach a stable state. </p>
+        <p>
+          This Working Group will follow a <a
+          href="https://github.com/w3c/testing-how-to/#test-as-you-commit">test
+          as you commit</a> approach to specification development, for
+          specifications in CR or above.
+        </p>
         <h3 id="rec-track"> Normative Specifications </h3>
         <p> The Working Group will deliver at least the following
           specifications: </p>

--- a/index.html
+++ b/index.html
@@ -44,21 +44,19 @@
             <td rowspan="1" colspan="1"> 31 December 2018 </td>
           </tr>
           <tr>
-            <th rowspan="1" colspan="1"> Confidentiality </th>
-            <td rowspan="1" colspan="1"> Proceedings are <a href="https://www.w3.org/2015/Process-20150901/#confidentiality-levels">
-                Public</a> </td>
+            <th rowspan="1" colspan="1"> Charter extension </th>
+            <td rowspan="1" colspan="1"> See <a href="#history">Change History</a> </td>
           </tr>
           <tr>
-            <th rowspan="1" colspan="1"> Initial Chairs </th>
+            <th rowspan="1" colspan="1"> Chairs </th>
             <td rowspan="1" colspan="1"> Anssi Kostiainen </td>
           </tr>
           <tr>
-            <th rowspan="1" colspan="1"> Initial Team Contacts<br />
-              (FTE %: 20) </th>
-            <td rowspan="1" colspan="1"> François Daoust </td>
+            <th rowspan="1" colspan="1"> Team Contacts</th>
+            <td rowspan="1" colspan="1"> François Daoust (0.2 FTE)</td>
           </tr>
           <tr>
-            <th rowspan="1" colspan="1"> Usual Meeting Schedule </th>
+            <th rowspan="1" colspan="1"> Meeting Schedule </th>
             <td rowspan="1" colspan="1"> Teleconferences: topic-specific calls
               may be held<br />
               Face-to-face: we will meet during the W3C's annual Technical
@@ -150,7 +148,7 @@
         <p> Members of the Working Group should review other Working Groups'
           deliverables that are identified as being relevant to the Working
           Group's mission. </p>
-        <h3> Success Criteria </h3>
+        <h3 id="success-criteria"> Success Criteria </h3>
         <p> To advance to <a href="https://www.w3.org/2015/Process-20150901/#RecsCR">Proposed
             Recommendation</a>, each specification is expected to have two
           independent implementations of each feature defined in the
@@ -217,7 +215,22 @@
               authorized pages. </p>
             <p class="draft-status"> <b>Draft state:</b> <a href="http://www.w3.org/TR/2016/CR-presentation-api-20160714/">
                 CR</a> / Stable </p>
-            <p class="milestone"> <b>Expected completion:</b> Q2 2017 </p>
+            <p class="milestone">
+              <b>Expected completion:</b> Q4 2019 &mdash; With the possible
+              exception of the testing API noted in <a href="#test-suite">Test
+              suite</a> below, this Working Group does not anticipate further
+              changes to this specification. That said, known implementations
+              plans are tied to the availability of the
+              <a href="https://github.com/webscreens/openscreenprotocol">Open
+              Screen Protocol</a>, under incubation in the
+              <a href="http://www.w3.org/community/webscreens/">Second Screen
+              Community Group</a>. The Working Group does not expect to be able
+              to meet the <a href="#success-criteria">Success Criteria</a> for
+              the Presentation API in the meantime. This Working Group plans to
+              assess progress on the suite of protocols at the end of this
+              Charter, and to request re-chartering accordingly to finalize the
+              specification.
+            </p>
           </dd>
           <dt> Presentation API Level 2 </dt>
           <dd>
@@ -247,16 +260,26 @@
             <p> An API that allows a web application to request display of media
               content on a connected display, with a means to control the remote
               playback from the initiating page and other authorized pages. </p>
-            <p class="draft-status"> <b>Draft state:</b> <a href="http://www.w3.org/TR/2016/WD-remote-playback-20160714/">
-                FPWD</a> / Refining </p>
-            <p class="milestone"> <b>Expected completion:</b> Q3 2017 </p>
+            <p class="draft-status"> <b>Draft state:</b> <a href="http://www.w3.org/TR/2017/CR-remote-playback-20171019/">
+                CR</a> / Stable </p>
+            <p class="milestone">
+              <b>Expected completion:</b> Q4 2018 &mdash; With the possible
+              exception of the testing API noted in <a href="#test-suite">Test
+              suite</a> below, this Working Group does not anticipate further
+              changes to this specification. As for the Presentation API,
+              progress on the
+              <a href="https://github.com/webscreens/openscreenprotocol">Open
+              Screen Protocol</a> will benefit this specification, but this
+              Working Group still expects to publish the Remote Playback API as
+              a final Recommendation in parallel to protocol discussions.
+            </p>
           </dd>
         </dl>
         <p> The Working Group may decide to group the API functions in one or
           more specifications. </p>
         <h3 id="other-deliverables"> Other Deliverables </h3>
         <dl>
-          <dt> Test suite </dt>
+          <dt id="test-suite"> Test suite </dt>
           <dd> A comprehensive test suite for all features of a specification is
             necessary to assess the specification's robustness, consistency, and
             implementability, and to promote interoperability between user
@@ -265,8 +288,15 @@
             Recommendation, and which must be completed with an implementation
             report before transition to Proposed Recommendation. Additional
             tests may be added to the test suite at any stage of the
-            Recommendation track, and the maintenance of a implementation report
-            is encouraged. </dd>
+            Recommendation track, and the maintenance of an implementation
+            report is encouraged. </dd>
+          <dd> Additionally, this Working Group will seek to define an testing
+            API surface for the Presentation API and for the Remote Playback API
+            with a view to improve test automation, as well as to allow
+            developers to test their own presentations. Depending on progress,
+            this Working Group may choose to include the testing API in the
+            existing drafts, or to define them in Level 2 versions of the
+            specifications. </dd>
           <dt> Use cases and requirements </dt>
           <dd> The Working Group is strongly encouraging the participants to
             create and maintain a use cases and requirements document for each
@@ -310,12 +340,12 @@
               <th rowspan="1" colspan="1"> Presentation API </th>
               <td class="WD1" rowspan="1" colspan="1"> - </td>
               <td class="CR" rowspan="1" colspan="1"> - </td>
-              <td class="PR" rowspan="1" colspan="1"> Q2 2017 </td>
-              <td class="REC" rowspan="1" colspan="1"> Q2 2017 </td>
+              <td class="PR" rowspan="1" colspan="1"> <em>Q4 2019</em> </td>
+              <td class="REC" rowspan="1" colspan="1"> <em>Q4 2019</em> </td>
             </tr>
             <tr>
               <th rowspan="1" colspan="1"> Presentation API Level 2 </th>
-              <td class="WD1" rowspan="1" colspan="1"> Q3 2017 </td>
+              <td class="WD1" rowspan="1" colspan="1"> Q2 2018 </td>
               <td class="CR" rowspan="1" colspan="1"> - </td>
               <td class="PR" rowspan="1" colspan="1"> - </td>
               <td class="REC" rowspan="1" colspan="1"> - </td>
@@ -323,9 +353,9 @@
             <tr>
               <th rowspan="1" colspan="1"> Remote Playback API </th>
               <td class="WD1" rowspan="1" colspan="1"> - </td>
-              <td class="CR" rowspan="1" colspan="1"> Q2 2017 </td>
-              <td class="PR" rowspan="1" colspan="1"> Q3 2017 </td>
-              <td class="REC" rowspan="1" colspan="1"> Q4 2017 </td>
+              <td class="CR" rowspan="1" colspan="1"> - </td>
+              <td class="PR" rowspan="1" colspan="1"> Q4 2018 </td>
+              <td class="REC" rowspan="1" colspan="1"> Q4 2018 </td>
             </tr>
           </tbody>
         </table>
@@ -335,49 +365,27 @@
         <h3 id="dependencies"> Dependencies </h3>
         <p> The initial draft of the Presentation API was prepared by the <a href="http://www.w3.org/community/webscreens/">Second
             Screen Community Group</a>. Upon approval of the Working Group, the
-          Community Group will cease its work on the Presentation API
-          specification. It is expected that the Community Group will recharter
-          to work on other related deliverables where it is not clear enough how
-          to proceed for it to be a work item for a Working Group. The Community
-          Group is only one possible source for work under future Working Group
-          charters, but can serve to do initial exploration for some future work
-          items. </p>
+          Community Group ceased its work on the Presentation API
+          specification. The Community Group is currently focused on incubating
+          the <a href="https://github.com/webscreens/openscreenprotocol">Open
+          Screen Protocol</a> for the APIs defined in this Working Group. The
+          Community Group may also work on other related deliverables where it
+          is not clear enough how to proceed for it to be a work item for a
+          Working Group. The Community Group is only one possible source for
+          work under future Working Group charters, but can serve to do initial
+        exploration for some future work items. </p>
         <p> The specifications produced by this Working Group adhere to the
           web's security model defined in the HTML specification published by
           the Web Platform Working Group. </p>
         <p> Common web technologies that this Working Group could refer to for
           messaging include Web Messaging and the Web Socket API defined by the
           Web Platform Working Group. </p>
-        <p> Even though the scopes of the APIs are different, some of the use
-          cases that the Presentation API aims to address, in particular
-          projection of web content on second screens connected to the local
-          area network, are also in scope of the Network Service Discovery API
-          worked upon by the Device and Sensors Working Group. This Working
-          Group will liaise with the Device and Sensors Working Group, in
-          particular to help ensure consistency of supported service discovery
-          mechanisms when a user agent implements both APIs. </p>
         <p> No external dependencies against the specifications of this Working
           Group have been identified. </p>
         <h3 id="liaisons"> Liaisons </h3>
-        <p> The Working Group expects to maintain contacts with at least the
-          following groups and Activities within W3C (in alphabetical order) and
-          ask for wide reviews of its deliverables before publication as
-          Candidate Recommendation, and where appropriate: </p>
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, and with the <a title="Technical Architecture Group" href="https://www.w3.org/2001/tag/">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a title="First Public Working Draft" href="https://www.w3.org/2017/Process-20170301/#RecsWD">FPWD</a> and at least 3 months before <a title="Candidate Recommendation" href="https://www.w3.org/2017/Process-20170301/#RecsCR">CR</a>, and should be issued when major changes occur in a specification.</p>
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/2017/Process-20170301/#WGCharter">W3C Process Document</a>:</p>
         <dl>
-          <dt><a href="http://www.w3.org/2009/dap/" id="dap"> Device and Sensors
-              Working Group </a></dt>
-          <dd> The Device and Sensors Working Group defines the Network Service
-            Discovery API that addresses some of the use cases that are in scope
-            of the Second Screen Working Group. </dd>
-          <dt><a href="http://www.w3.org/html/wg/" id="hme"> HTML Media
-              Extensions Working Group </a></dt>
-          <dd> The Second Screen Working Group may interact with the HTML Media
-            Extensions Working Group on the interaction between media extensions
-            and the Remote Playback API specification. </dd>
-          <dt><a href="http://www.w3.org/Privacy/"> Privacy Interest Group </a></dt>
-          <dd> The Second Screen Working Group intends to secure reviews on its
-            deliverables from the Privacy Interest Group to help ensure they
-            offer the right level of protection to users. </dd>
           <dt><a href="http://www.w3.org/community/webscreens/" id="sspcg">
               Second Screen Community Group </a></dt>
           <dd> This group developed the initial version of the Presentation API
@@ -394,8 +402,8 @@
             technologies, and inclusion in the deliverable of guidance for
             implementing the group’s deliverables in ways that support
             accessibility requirements. </dd>
-          <dt><a href="http://www.w3.org/2011/webtv/"> Web and TV Interest Group
-            </a></dt>
+          <dt><a href="http://www.w3.org/2011/webtv/"> Media and Entertainment
+          Interest Group</a></dt>
           <dd> This group provides use cases and requirements for second screen
             scenarios and thus important input on the deliverables developed by
             the Second Screen Working Group. </dd>
@@ -415,11 +423,6 @@
             specifications for establishing peer-to-peer communication channels
             and for extending the Presentation API to support out-of-scope
             features such as content mirroring. </dd>
-          <dt><a href="http://www.w3.org/Security/wiki/IG"> Web Security
-              Interest Group </a></dt>
-          <dd> The Second Screen Working Group intends to secure reviews on its
-            deliverables from the Web Security Interest Group to help ensure
-            they offer the right level of security. </dd>
         </dl>
         <h3 id="external-groups"> External Groups </h3>
         <p> The Presentation API does not have strong dependencies on any given
@@ -434,9 +437,9 @@
           <dt><a href="http://www.ietf.org" id="ietf">IETF</a></dt>
           <dd> The IETF develops home network protocols that secondary displays
             may support. </dd>
-          <dt><a href="http://www.upnp.org/">UPnP Forum</a></dt>
-          <dd> The UPnP Forum develops home network protocols that secondary
-            displays may support. </dd>
+          <dt><a href="http://openconnectivity.org/">Open Connectivity Foundation</a></dt>
+          <dd> The Open Connectivity Foundation develops home network protocols that secondary
+            displays may support, including the UPnP suite of protocols. </dd>
           <dt><a href="http://www.wi-fi.org/">Wi-Fi Alliance</a></dt>
           <dd> The Wi-Fi Alliance develops home network protocols that secondary
             displays may support. </dd>
@@ -444,7 +447,7 @@
         <div class="participation">
           <h2 id="participation"> Participation </h2>
           <p> To be successful, the Second Screen Working Group is expected to
-            have 10 or more active participants for its duration, and to have
+            have 6 or more active participants for its duration, and to have
             the participation of industry leaders in fields relevant to the
             specifications it produces. </p>
           <p> The Chairs and specification Editors are expected to contribute
@@ -539,7 +542,7 @@
                 <td> none </td>
               </tr>
               <tr>
-                <th> <a href="#">Rechartered</a> </th>
+                <th> <a href="https://www.w3.org/2014/secondscreen/charter-2016.html">Rechartered</a> </th>
                 <td> 3 November 2016 </td>
                 <td> 31 October 2017 </td>
                 <td>
@@ -554,20 +557,35 @@
                 </td>
               </tr>
               <tr>
-                <th> <a href="#">Extended</a> </th>
+                <th> <a href="https://www.w3.org/2014/secondscreen/charter-2016.html">Extended</a> </th>
                 <td> 17 October 2017 </td>
                 <td> 31 December 2017 </td>
                 <td> End date adjusted </td>
+              </tr>
+              <tr>
+                <th> <a href="#">Rechartered</a> </th>
+                <td> <span class="todo">1 January 2018</span> </td>
+                <td> 31 December 2018 </td>
+                <td>
+                  <ul>
+                    <li>Completion dates updated to reflect current
+                      implementation plans, dependency on Open Screen Protocol noted</li>
+                    <li>Intent to work on a testing API noted in Test suite section</li>
+                    <li>Dropped reference to the discontinued Network Service Discovery API which was developed by the Device and Sensors Working Group</li>
+                    <li>Updated boilerplate text using current charter template</li>
+                    <li>Adjusted group names in liaisons section accordingly</li>
+                  </ul>
+                </td>
               </tr>
             </tbody>
           </table>
         </section>
         <hr />
-        <p class="copyright"> <a rel="Copyright" href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>©
-          2016 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a>
-          <sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-          <a href="http://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-          <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>),
+        <p class="copyright"> <a rel="Copyright" href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>©
+          2017 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a>
+          <sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+          <a href="https://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+          <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>),
           All Rights Reserved. <abbr title="World Wide Web Consortium">W3C</abbr>
           <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
           <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>

--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
               <b>Expected completion:</b> Q4 2019 &mdash; With the possible
               exception of the testing API noted in <a href="#test-suite">Test
               suite</a> below, this Working Group does not anticipate further
-              changes to this specification. That said, known implementations
+              changes to this specification. That said, known implementation
               plans are tied to the availability of the
               <a href="https://github.com/webscreens/openscreenprotocol">Open
               Screen Protocol</a>, under incubation in the
@@ -290,13 +290,13 @@
             tests may be added to the test suite at any stage of the
             Recommendation track, and the maintenance of an implementation
             report is encouraged. </dd>
-          <dd> Additionally, this Working Group will seek to define an testing
-            API surface for the Presentation API and for the Remote Playback API
+          <dd> Additionally, this Working Group will seek to define a testing
+            API for the Presentation API and for the Remote Playback API
             with a view to improve test automation, as well as to allow
-            developers to test their own presentations. Depending on progress,
-            this Working Group may choose to include the testing API in the
-            existing drafts, or to define them in Level 2 versions of the
-            specifications. </dd>
+            developers to test their own web applications that make use of the
+            above-mentioned APIs. Depending on progress, this Working Group may
+            choose to include the testing APIs in the existing drafts, or to
+            define them in Level 2 versions of the specifications. </dd>
           <dt> Use cases and requirements </dt>
           <dd> The Working Group is strongly encouraging the participants to
             create and maintain a use cases and requirements document for each
@@ -392,8 +392,10 @@
             and focuses on enabling interoperability among implementations of
             the Presentation API, encouraging implementation of the Presentation
             API by browser vendors and establishing complementary specifications
-            for the Presentation API. The Community Group will specify a set of
-            network protocols that may warrant changes in the Presentation API.
+            for the Presentation API. The Community Group incubates the
+            <a href="https://github.com/webscreens/openscreenprotocol">Open
+            Screen Protocol</a> for the APIs defined in this Working Group.
+            This work on protocols may warrant changes in the Presentation API.
           </dd>
           <dt><a id="wai" href="http://www.w3.org/WAI/"> </a><a href="http://www.w3.org/WAI/APA/">Accessible
               Platform Architectures (APA) Working Group</a> </dt>
@@ -570,7 +572,7 @@
                   <ul>
                     <li>Completion dates updated to reflect current
                       implementation plans, dependency on Open Screen Protocol noted</li>
-                    <li>Intent to work on a testing API noted in Test suite section</li>
+                    <li>Intent to work on testing APIs noted in Test suite section</li>
                     <li>Dropped reference to the discontinued Network Service Discovery API which was developed by the Device and Sensors Working Group</li>
                     <li>Updated boilerplate text using current charter template</li>
                     <li>Adjusted group names in liaisons section accordingly</li>


### PR DESCRIPTION
The following changes were made:
- Completion dates were updated to reflect current implementation plans, and the dependency on Open Screen Protocol was noted in particular to justify the completion date of the Presentation API in Q4 2019.
- The intent to work on a testing API was noted in Test suite section. The text gives freedom to the Working Group to put that testing API in the current drafts or in Level 2 specs.
- The reference to the Network Service Discovery API was dropped
- The "boilerplate" text was updated to match latest template, in particular in the coordination section (I did not try to inject all template updates though, so as to keep diff minimal)
- The liaisons section was adjusted.

I note that the Charter still says that mandating protocols is out of scope of the Working Group. In other words, as things stand, the Working Group cannot add text such as "the user agent MUST support the Open Screen Protocol" to the Presentation API and Remote Playback API.