### PR TITLE
Adjust charter text to new template, refresh links and liaisons

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,25 +134,9 @@
           Synchronization of web content among multiple connections may be
           possible, but is not defined by the specifications in this group.
         </p>
-        <p> The specifications produced by this Working Group will include
-          security and privacy considerations. Specifically, the user must
-          always be in control of privacy-sensitive information that may be
-          conveyed through the APIs, such as the visibility or access to
-          presentation displays, or the URLs of the web content to be presented. </p>
         <p> Members of the Working Group should review other Working Groups'
           deliverables that are identified as being relevant to the Working
           Group's mission. </p>
-        <h3 id="success-criteria"> Success Criteria </h3>
-        <p> To advance to <a href="https://www.w3.org/2015/Process-20150901/#RecsCR">Proposed
-            Recommendation</a>, each specification is expected to have two
-          independent implementations of each feature defined in the
-          specification. </p>
-        <p> To advance to Proposed Recommendation, interoperability between the
-          independent implementations should be demonstrated. Interoperable user
-          agents hosting the same Presentation API web application should be
-          able to render the same content with the same functionality on
-          supported presentation displays that are compatible with the content to
-          render. </p>
         <h3 id="out-of-scope"> Out of Scope </h3>
         <p> The specifications defined by this Working Group abstract away the
           means of connecting and different connection technologies. For
@@ -179,7 +163,7 @@
         being incubated as
         the <a href="https://webscreens.github.io/openscreenprotocol/"> Open
         Screen Protocol</a> in
-        the <a href="http://www.w3.org/community/webscreens/"> Second Screen
+        the <a href="https://www.w3.org/community/webscreens/"> Second Screen
         Community Group</a>.  The Working Group will informatively reference the
         Open Screen Protocol in its API specifications.
         </p>
@@ -194,24 +178,18 @@
           the call for participation. Expected completion indicates when the
           deliverable is projected to become a Recommendation, or otherwise
           reach a stable state. </p>
-        <p>
-          This Working Group will follow a <a
-          href="https://github.com/w3c/testing-how-to/#test-as-you-commit">test
-          as you commit</a> approach to specification development, for
-          specifications in CR or above.
-        </p>
         <h3 id="rec-track"> Normative Specifications </h3>
         <p> The Working Group will deliver at least the following
           specifications: </p>
         <dl>
-          <dt> <a href="http://www.w3.org/TR/presentation-api/">Presentation
+          <dt> <a href="https://www.w3.org/TR/presentation-api/">Presentation
               API</a> </dt>
           <dd>
             <p> An API that allows a web application to request display of web
               content on a connected display, with a means to communicate with
               and control the web content from the initiating page and other
               authorized pages. </p>
-            <p class="draft-status"> <b>Draft state:</b> <a href="http://www.w3.org/TR/2016/CR-presentation-api-20160714/">
+            <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/2017/CR-presentation-api-20170601/">
                 CR</a> / Stable </p>
             <p class="milestone">
               <b>Expected completion:</b> Q4 2021 &mdash; The Working Group is
@@ -226,7 +204,7 @@
             <p>
               The <a href="https://github.com/webscreens/openscreenprotocol">
               Open Screen Protocol</a>, under incubation in
-              the <a href="http://www.w3.org/community/webscreens/"> Second
+              the <a href="https://www.w3.org/community/webscreens/"> Second
               Screen Community Group</a>, will be the basis for demonstrating
               interoperability between browsers and devices.  Two
               implementations based on it would satisfy those criteria. The
@@ -262,13 +240,13 @@
             </p>
             
           </dd>
-          <dt> <a href="http://www.w3.org/TR/remote-playback/">Remote Playback
+          <dt> <a href="https://www.w3.org/TR/remote-playback/">Remote Playback
               API</a> </dt>
           <dd>
             <p> An API that allows a web application to request display of media
               content on a connected display, with a means to control the remote
               playback from the initiating page and other authorized pages. </p>
-            <p class="draft-status"> <b>Draft state:</b> <a href="http://www.w3.org/TR/2017/CR-remote-playback-20171019/">
+            <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/2017/CR-remote-playback-20171019/">
                 CR</a> / Stable </p>
             <p class="milestone">
               <b>Expected completion:</b> Q4 2020 &mdash; The Working Group
@@ -383,11 +361,35 @@
           </tbody>
         </table>
       </div>
+      <div id="success-criteria">
+        <h2> Success Criteria </h2>
+        <p> To advance to <a href="https://www.w3.org/2015/Process-20150901/#RecsCR">Proposed
+            Recommendation</a>, each specification is expected to have two
+          independent implementations of each feature defined in the
+          specification. </p>
+        <p> To advance to Proposed Recommendation, interoperability between the
+          independent implementations should be demonstrated. Interoperable user
+          agents hosting the same Presentation API web application should be
+          able to render the same content with the same functionality on
+          supported presentation displays that are compatible with the content to
+          render. </p>
+        <p> The specifications produced by this Working Group will include
+          security and privacy considerations. Specifically, the user must
+          always be in control of privacy-sensitive information that may be
+          conveyed through the APIs, such as the visibility or access to
+          presentation displays, or the URLs of the web content to be presented. </p>
+        <p>
+          This Working Group will follow a <a
+          href="https://www.w3.org/2019/02/testing-policy.html">test
+          as you commit</a> approach to specification development, for
+          specifications in CR or above.
+        </p>
+      </div>
       <div class="dependencies">
         <h2 id="coordination"> Dependencies and Liaisons </h2>
         <h3 id="dependencies"> Dependencies </h3>
         <p> The initial draft of the Presentation API was prepared by the
-          <a href="http://www.w3.org/community/webscreens/">Second
+          <a href="https://www.w3.org/community/webscreens/">Second
             Screen Community Group</a>. Upon approval of the Working Group, the
           Community Group ceased its work on the Presentation API
           specification. The Community Group is currently focused on incubating
@@ -426,7 +428,7 @@
         the <a href="https://www.w3.org/2017/Process-20170301/#WGCharter">W3C
         Process Document</a>: </p>
         <dl>
-          <dt><a href="http://www.w3.org/community/webscreens/" id="sspcg">
+          <dt><a href="https://www.w3.org/community/webscreens/" id="sspcg">
               Second Screen Community Group </a></dt>
           <dd> This group developed the initial version of the Presentation API
             and focuses on enabling interoperability among implementations of
@@ -436,29 +438,19 @@
             <a href="https://github.com/webscreens/openscreenprotocol">Open
             Screen Protocol</a> for the APIs defined in this Working Group.
           </dd>
-          <dt><a id="wai" href="http://www.w3.org/WAI/"> </a><a href="http://www.w3.org/WAI/APA/">Accessible
+          <dt><a id="wai" href="https://www.w3.org/WAI/"> </a><a href="https://www.w3.org/WAI/APA/">Accessible
               Platform Architectures (APA) Working Group</a> </dt>
           <dd> To help ensure deliverables support accessibility requirements,
             particularly with regard to interoperability with assistive
             technologies, and inclusion in the deliverable of guidance for
             implementing the group’s deliverables in ways that support
             accessibility requirements. </dd>
-          <dt><a href="http://www.w3.org/2011/webtv/"> Media and Entertainment
+          <dt><a href="https://www.w3.org/2011/webtv/"> Media and Entertainment
           Interest Group</a></dt>
           <dd> This group provides use cases and requirements for second screen
             scenarios and thus important input on the deliverables developed by
             the Second Screen Working Group. </dd>
-          <dt><a href="http://www.w3.org/html/wg/" id="html"> Web Platform
-              Working Group </a></dt>
-          <dd> The Web Platform Working Group’s deliverables cover the security
-            model implemented in Web Browsers; as well as other relevant
-            specifications such as <cite><a href="http://www.w3.org/TR/WebIDL/">Web
-                IDL</a></cite>, <cite><a href="http://www.w3.org/TR/webmessaging/">HTML5
-                Web Messaging</a></cite>, <cite><a href="http://www.w3.org/TR/websockets/">The
-                Web Socket API</a></cite> and the <a href="http://www.w3.org/TR/html/">HTML</a>
-            specification that contain the definition of the <code>HTMLMediaElement</code>
-            interface that the Remote Playback API specification extends. </dd>
-          <dt><a href="http://www.w3.org/2011/04/webrtc/"> Web Real-Time
+          <dt><a href="https://www.w3.org/2011/04/webrtc/"> Web Real-Time
               Communications Working Group </a></dt>
           <dd> This group defines relevant or potentially relevant
             specifications for establishing peer-to-peer communication channels
@@ -472,13 +464,22 @@
           Presentation API to be implemented on top of widely deployed
           attachment methods for connected displays: </p>
         <dl>
-          <dt><a href="http://www.ietf.org" id="ietf">IETF</a></dt>
+          <dt><a href="https://www.ietf.org" id="ietf">IETF</a></dt>
           <dd> The IETF develops home network protocols that presentation displays
             may support. </dd>
-          <dt><a href="http://openconnectivity.org/">Open Connectivity Foundation</a></dt>
+          <dt><a href="https://openconnectivity.org/">Open Connectivity Foundation</a></dt>
           <dd> The Open Connectivity Foundation develops home network protocols that presentation
             displays may support, including the UPnP suite of protocols. </dd>
-          <dt><a href="http://www.wi-fi.org/">Wi-Fi Alliance</a></dt>
+          <dt><a href="https://spec.whatwg.org/" id="whatwg">Web Hypertext Application Technology Working Group</a> (WHATWG)</dt>
+          <dd> WHATWG develops the <a href="https://html.spec.whatwg.org/">HTML</a>
+            specification that contains the definition of the
+            <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a>
+            interface that the Remote Playback API specification extends; as
+            well as the <a href="https://html.spec.whatwg.org/#network">Web sockets</a>
+            and the <a href="https://html.spec.whatwg.org/#web-messaging">cross-document
+            messaging</a> interfaces after which the communication channel of the
+            Presentation API is modeled.</dd>
+          <dt><a href="https://www.wi-fi.org/">Wi-Fi Alliance</a></dt>
           <dd> The Wi-Fi Alliance develops home network protocols that presentation
             displays may support. </dd>
         </dl>
@@ -502,7 +503,7 @@
           <h2 id="communication"> Communication </h2>
           <p> Teleconferences will be conducted on an as-needed basis. </p>
           <p> This group primarily conducts its work on the public mailing list
-            <a href="http://lists.w3.org/Archives/Public/public-secondscreen/">public-secondscreen@w3.org</a>.
+            <a href="https://lists.w3.org/Archives/Public/public-secondscreen/">public-secondscreen@w3.org</a>.
             Administrative tasks may be conducted in Member-only communications.
           </p>
           <p> Information about the group (deliverables, participants,
@@ -558,13 +559,13 @@
         </div>
         <div class="patent">
           <h2 id="patentpolicy"> Patent Policy </h2>
-          <p> This Working Group operates under the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/">W3C
-              Patent Policy</a> (5 February 2004 Version). To promote the widest
+          <p> This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C
+              Patent Policy</a> (Version of 5 February 2004 updated 1 August 2017). To promote the widest
             adoption of Web standards, W3C seeks to issue Recommendations that
             can be implemented, according to this policy, on a Royalty-Free
             basis. </p>
           <p> For more information about disclosure obligations for this group,
-            please see the <a href="http://www.w3.org/2004/01/pp-impl/">W3C
+            please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C
               Patent Policy Implementation</a>. </p>
         </div>
         <div id="licensing">
@@ -574,15 +575,15 @@
         </div>
         <h2 id="about"> About this Charter </h2>
         <p> This charter for the Second Screen Working Group has been created
-          according to <a href="http://www.w3.org/Consortium/Process/groups#GAGeneral">section
-            5</a> of the <a href="http://www.w3.org/Consortium/Process">Process
+          according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section
+            5.2</a> of the <a href="https://www.w3.org/Consortium/Process">Process
             Document</a>. In the event of a conflict between this document or
           the provisions of any charter and the W3C Process, the W3C Process
           shall take precedence. </p>
         <section id="history">
           <h3> Charter History </h3>
           <p>The following table lists details of all changes from the initial
-            charter, per the <a href="https://www.w3.org/2015/Process-20150901/#CharterReview">W3C
+            charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C
               Process Document (section 5.2.3)</a>:</p>
           <table class="history">
             <tbody>
@@ -656,10 +657,10 @@
         </section>
         <hr />
         <p class="copyright"> <a rel="Copyright" href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>©
-          2017 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a>
+          2019 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a>
           <sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
           <a href="https://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-          <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>),
+          <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>),
           All Rights Reserved. <abbr title="World Wide Web Consortium">W3C</abbr>
           <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
           <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US">
   <head>
     <meta charset="utf-8" />
-    <title> Second Screen Working Group </title>
+    <title> Second Screen Working Group Charter </title>
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css"
       media="screen" />
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/pubrules-style.css" />


### PR DESCRIPTION
These updates bring the proposed charter more in line with the current charter template and refreshes the contents of the charter:
- Move success criteria section out of the "Scope" section, and move texts on security/privacy section and on test-as-you-commit approach there.
- Update HTTP links to HTTPS
- Update URL of Presentation API CR
- Replace liaison with Web Platform WG by a liaison with WHATWG
- Update reference to the Patent Policy and link to Process document
- Update copyright year