### PR TITLE
Update boilerplate text to latest version of charter templare

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,23 +7,69 @@
       media="screen" />
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/Guide/pubrules-style.css" />
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css" />
+    <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
+      ul#navbar {
+        font-size: small;
+      }
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: #900;
+      }
+
+      footer {
+        font-size: small;
+      }
+    </style>
   </head>
   <body>
-    <div id="template">
-      <ul id="navbar" style="font-size: small">
-        <li> <a href="#goals">Goals</a> </li>
-        <li> <a href="#scope">Scope</a> </li>
-        <li> <a href="#deliverables">Deliverables</a> </li>
-        <li> <a href="#coordination">Dependencies and Liaisons</a> </li>
-        <li> <a href="#participation">Participation</a> </li>
-        <li> <a href="#communication">Communication</a> </li>
-        <li> <a href="#decisions">Decision Policy</a> </li>
-        <li> <a href="#patentpolicy">Patent Policy</a> </li>
-        <li> <a href="#licensing">Licensing</a> </li>
-        <li> <a href="#about">About this Charter</a> </li>
-      </ul>
-      <p> <a href="https://www.w3.org/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="#background">Background</a></li>
+          <li><a href="#scope">Scope</a></li>
+          <li><a href="#deliverables">Deliverables</a></li>
+          <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#coordination">Coordination</a></li>
+          <li><a href="#participation">Participation</a></li>
+          <li><a href="#communication">Communication</a></li>
+          <li><a href="#decisions">Decision Policy</a></li>
+          <li><a href="#patentpolicy">Patent Policy</a></li>
+          <li><a href="#licensing">Licensing</a></li>
+          <li><a href="#about">About this Charter</a></li>
+        </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
       </p>
+    </header>
+
+    <main>
       <h1 id="title"><span class="todo">[PROPOSED]</span> Second Screen Working Group Charter </h1>
       <p class="todo"><strong>Warning:</strong> This document has no official status. It is a draft charter for discussion within the Second Screen WG and the W3C Advisory Committee.</p>
       <p class="mission"> The <strong>mission</strong> of
@@ -32,18 +78,20 @@
           to use secondary screens (presentation displays) to display web
           content. </p>
       <div class="noprint">
-        <p class="join"> <a href="https://www.w3.org/2004/01/pp-impl/74168/join">Join
+        <p class="join"> <a href="https://www.w3.org/groups/wg/secondscreen/join">Join
             the Second Screen Working Group</a> </p>
       </div>
-      <table class="summary-table">
+
+      <section id="details">
+        <table class="summary-table">
         <tbody>
           <tr id="Duration">
             <th rowspan="1" colspan="1"> Start date </th>
-            <td rowspan="1" colspan="1"> 11 December 2019 </td>
+            <td rowspan="1" colspan="1"> <i class="todo">@@ January 2022</i> </td>
           </tr>
           <tr>
             <th rowspan="1" colspan="1"> End date </th>
-            <td rowspan="1" colspan="1"> 31 December 2021 </td>
+            <td rowspan="1" colspan="1"> 31 January 2024 </td>
           </tr>
           <tr>
             <th rowspan="1" colspan="1"> Charter extension </th>
@@ -55,7 +103,7 @@
           </tr>
           <tr>
             <th rowspan="1" colspan="1"> Team Contacts</th>
-            <td rowspan="1" colspan="1"> François Daoust (0.1 FTE)</td>
+            <td rowspan="1" colspan="1"> <a href="mailto:fd@w3.org">François Daoust</a> (0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</td>
           </tr>
           <tr>
             <th rowspan="1" colspan="1"> Meeting Schedule </th>
@@ -69,9 +117,11 @@
               IRC channel during F2F meetings and teleconferences. </td>
           </tr>
         </tbody>
-      </table>
-      <div class="goals">
-        <h2 id="goals"> Goals </h2>
+        </table>
+      </section>
+
+      <section id="background" class="background">
+        <h2> Background </h2>
         <p> Web applications are available on an ever expanding array of devices
           including e-book readers, phones, tablets, laptops, auto displays, and
           electronic signs.  A variety of mechanisms allow
@@ -96,9 +146,10 @@
           existing IETF protocols) that allow web applications to present
           and control web content on one or more presentation displays and
           speakers. </p>
-      </div>
-      <div class="scope">
-        <h2 id="scope"> Scope </h2>
+      </section>
+
+      <section id="scope" class="scope">
+        <h2> Scope </h2>
         <p> The scope of this Working Group is to define:</p>
         <ul>
           <li>APIs that allow a web
@@ -162,287 +213,307 @@
         <p> Members of the Working Group should review other Working Groups'
           deliverables that are identified as being relevant to the Working
           Group's mission. </p>
-        <h3 id="out-of-scope"> Out of Scope </h3>
-        <p> The specifications defined by this Working Group abstract away the
-          means of connecting and different connection technologies. For
-          example, the following are out of scope: </p>
-        <ul>
-          <li>Lower level APIs that expose features of existing connection
-            technologies;</li>
-          <li>How presentation displays are connected to the primary device (e.g. Video
-            Port, HDMI, WiDi, Miracast, AirPlay);</li>
-          <li>How the user agent prepares and sends the screen contents to the
-            presentation display.</li>
-        </ul>
-        <p> This Working Group will reuse and configure existing network
-          protocols to create an open suite of network protocols suitable for
-          the APIs. As such, the following are out of scope for the Working
-          Group: </p>
-        <ul>
-          <li>Any new feature in existing IETF protocols normatively referenced
-            by the suite of network protocols;</li>
-          <li>Any new protocol for discovery, authentication, transport and
-            messaging;</li>
-          <li>Any protocol not required to implement the APIs developed by this
-            Working Group.</li>
-        </ul>
-        <p> Input methods, such as using a TV remote as a pointer or clicker,
-          are out of scope of the Working Group. </p>
-        <p> This Working Group will not define or mandate any video or audio
-          codecs. </p>
-      </div>
-      <div>
-        <h2 id="deliverables"> Deliverables </h2>
+
+        <section id="out-of-scope">
+          <h3> Out of Scope </h3>
+          <p> The specifications defined by this Working Group abstract away the
+            means of connecting and different connection technologies. For
+            example, the following are out of scope: </p>
+          <ul>
+            <li>Lower level APIs that expose features of existing connection
+              technologies;</li>
+            <li>How presentation displays are connected to the primary device (e.g. Video
+              Port, HDMI, WiDi, Miracast, AirPlay);</li>
+            <li>How the user agent prepares and sends the screen contents to the
+              presentation display.</li>
+          </ul>
+          <p> This Working Group will reuse and configure existing network
+            protocols to create an open suite of network protocols suitable for
+            the APIs. As such, the following are out of scope for the Working
+            Group: </p>
+          <ul>
+            <li>Any new feature in existing IETF protocols normatively referenced
+              by the suite of network protocols;</li>
+            <li>Any new protocol for discovery, authentication, transport and
+              messaging;</li>
+            <li>Any protocol not required to implement the APIs developed by this
+              Working Group.</li>
+          </ul>
+          <p> Input methods, such as using a TV remote as a pointer or clicker,
+            are out of scope of the Working Group. </p>
+          <p> This Working Group will not define or mandate any video or audio
+            codecs. </p>
+        </section>
+      </section>
+
+      <section id="deliverables"> Deliverables </h2>
         <p> Draft state indicates the state of the deliverable at the time of
-          the call for participation. Expected completion indicates when the
+          the charter approval. Expected completion indicates when the
           deliverable is projected to become a Recommendation, or otherwise
           reach a stable state. </p>
-        <h3 id="rec-track"> Normative Specifications </h3>
-        <p> The Working Group will deliver at least the following
-          specifications: </p>
-        <dl>
-          <dt> <a href="https://www.w3.org/TR/presentation-api/">Presentation
-              API</a></dt>
-          <dd>
-            <p> An API that allows a web application to request display of web
-              content on a connected display, with a means to communicate with
-              and control the web content from the initiating page and other
-              authorized pages. </p>
-            <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/2017/CR-presentation-api-20170601/">
-                CR</a> / Stable </p>
-            <p class="milestone">
-              <b>Expected completion:</b> Q4 2021 &mdash; The Working Group is
-              awaiting satisfaction of the <a href="#success-criteria">Success
-              Criteria</a>, which require two interoperable implementations of
-              the Presentation API.  The Working Group will also await
-              demonstration of interoperability among multiple browsers and
-              multiple presentation displays before moving the specification to
-              Proposed Recommendation.
-            </p>
-            <p>
-              <b>Reference Draft:</b>
-              <a href="https://www.w3.org/TR/2017/CR-presentation-api-20170601/">https://www.w3.org/TR/2017/CR-presentation-api-20170601/</a><br>
-              Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2017Oct/0005.html">Call for Exclusion</a>
-              on 19 October 2017 ended on 31 July 2017<br>
-              Produced under Working Group Charter: https://www.w3.org/2014/secondscreen/charter-2016.html
-            </p>
-            <p>
-              The <a href="https://github.com/webscreens/openscreenprotocol">
-              Open Screen Protocol</a> will be the basis for demonstrating
-              interoperability between browsers and devices.  Two
-              implementations based on it would satisfy those criteria. The
-              charter timeline provides additional time for Open Screen Protocol
-              implementations to be completed and the Success Criteria to be
-              met.
-            </p>
-            <p>
-              A second version of the Presentation API that integrates features
-              the Working Group resolved not to include in the first version in
-              the interest of time, and also feedback from Web developers on the
-              first version, will first be incubated and matured in an
-              appropriate Community Group. This Working Group expects to bring
-              such features out of incubation through rechartering, when the
-              criteria for moving the current Presentation API to Proposed
-              Recommendation have been met.
-            </p>
 
-            <p>
-              Additional features will be considered for the Presentation API to
-              align it with the work on the Open Screen Protocol, based on
-              implementation experience with that protocol.
-            </p>
-            <p>
-              Additional features will also be considered to improve
-              compatibility with the Remote Playback API and presentation of
-              additional media types that are supported by the Open Screen
-              Protocol.
-            </p>
-            <p>
-              All API changes will be incubated in the Second Screen Community
-              Group before being considered in the Working Group.
-            </p>
+        <section id="normative">
+          <h3> Normative Specifications </h3>
+          <p> The Working Group will deliver at least the following
+            specifications: </p>
+          <dl>
+            <dt> <a href="https://www.w3.org/TR/presentation-api/">Presentation
+                API</a></dt>
+            <dd>
+              <p> An API that allows a web application to request display of web
+                content on a connected display, with a means to communicate with
+                and control the web content from the initiating page and other
+                authorized pages. </p>
+              <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/2017/CR-presentation-api-20170601/">
+                  CR</a> / Stable </p>
+              <p class="milestone">
+                <b>Expected completion:</b> Q4 2021 &mdash; The Working Group is
+                awaiting satisfaction of the <a href="#success-criteria">Success
+                Criteria</a>, which require two interoperable implementations of
+                the Presentation API.  The Working Group will also await
+                demonstration of interoperability among multiple browsers and
+                multiple presentation displays before moving the specification to
+                Proposed Recommendation.
+              </p>
+              <p>
+                <b>Reference Draft:</b>
+                <a href="https://www.w3.org/TR/2017/CR-presentation-api-20170601/">https://www.w3.org/TR/2017/CR-presentation-api-20170601/</a><br>
+                Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2017Oct/0005.html">Call for Exclusion</a>
+                on 19 October 2017 ended on 31 July 2017<br>
+                Produced under Working Group Charter: https://www.w3.org/2014/secondscreen/charter-2016.html
+              </p>
+              <p>
+                The <a href="https://github.com/webscreens/openscreenprotocol">
+                Open Screen Protocol</a> will be the basis for demonstrating
+                interoperability between browsers and devices.  Two
+                implementations based on it would satisfy those criteria. The
+                charter timeline provides additional time for Open Screen Protocol
+                implementations to be completed and the Success Criteria to be
+                met.
+              </p>
+              <p>
+                A second version of the Presentation API that integrates features
+                the Working Group resolved not to include in the first version in
+                the interest of time, and also feedback from Web developers on the
+                first version, will first be incubated and matured in an
+                appropriate Community Group. This Working Group expects to bring
+                such features out of incubation through rechartering, when the
+                criteria for moving the current Presentation API to Proposed
+                Recommendation have been met.
+              </p>
 
-          </dd>
-          <dt> <a href="https://www.w3.org/TR/remote-playback/">Remote Playback
-              API</a></dt>
-          <dd>
-            <p> An API that allows a web application to request display of media
-              content on a connected display, with a means to control the remote
-              playback from the initiating page and other authorized pages. </p>
-            <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/2017/CR-remote-playback-20171019/">
-                CR</a> / Stable </p>
-            <p class="milestone">
-              <b>Expected completion:</b> Q4 2020 &mdash; The Working Group
-              plans to publish the Remote Playback API as a final Recommendation
-              when the Success Criteria are met.
-            </p>
-            <p>
-              <b>Reference Draft:</b>
-              <a href="https://www.w3.org/TR/2017/CR-remote-playback-20171019/">https://www.w3.org/TR/2017/CR-remote-playback-20171019/</a><br>
-              Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2017Oct/0005.html">Call for Exclusion</a>
-              on 19 October 2017 ended on 18 December 2017<br>
-              Produced under Working Group Charter: https://www.w3.org/2014/secondscreen/charter-2016.html
-            </p>
-            <p>
-              Additional features will be considered for the Remote Playback API
-              to align it with the work on the Open Screen Protocol, based on
-              implementation experience with that protocol.
-            </p>
-            <p>
-              Additional features will also be considered to improve
-              compatibility with the Presentation API and remote playback of
-              additional media types that are supported by the Open Screen
-              Protocol.
-            </p>
-            <p>
-              All API changes will be incubated in the Second Screen Community
-              Group before being considered in the Working Group.
-            </p>
-          </dd>
-          <dt> <a href="https://webscreens.github.io/openscreenprotocol/">Open Screen Protocol</a> </dt>
-          <dd>
-            <p>
-              A suite of network protocols that allow user agents to implement
-              the Presentation API and the Remote Playback API in an
-              interoperable fashion for browsers and presentation displays
-              connected via the same local area network.
-            </p>
-            <p class="draft-status"> <b>Draft state:</b> <a href="https://webscreens.github.io/openscreenprotocol/">
-                Adopted from the Second Screen Community Group</a></p>
-            <p class="milestone">
-              <b>Expected completion:</b> Q2 2021
-            </p>
-          </dd>
-        </dl>
-        <p> The Working Group may decide to group the API and protocol suite
-          in one or more specifications. </p>
-        <h3 id="other-deliverables"> Other Deliverables </h3>
-        <dl>
-          <dt id="test-suite"> Test suite </dt>
-          <dd>
-            <p>
-              A comprehensive test suite for all features of a specification is
-              necessary to assess the specification's robustness, consistency, and
-              implementability, and to promote interoperability between user
-              agents. Therefore, each specification must have a companion test
-              suite, which should be completed before transition to Candidate
-              Recommendation, and which must be completed with an implementation
-              report before transition to Proposed Recommendation. Additional
-              tests may be added to the test suite at any stage of the
-              Recommendation track, and the maintenance of an implementation
-              report is encouraged.
-            </p>
-            <p>
-              Additionally, this Working Group will improve test automation for
-              the Presentation API and Remote Playback API test suites. This
-              will be done through the adoption of a Testing API, incubated in
-              an appropriate Community Group. The Testing API will also allow
-              developers to use automation to test their own Web applications
-              that make use of the above-mentioned APIs.
-            </p>
-          </dd>
-          <dt> Use cases and requirements </dt>
-          <dd>
-            <p>
-              The Working Group is strongly encouraging the participants to
-              create and maintain a use cases and requirements document for each
-              specification.
-            </p>
-          </dd>
-          <dt> Implementation guidelines </dt>
-          <dd>
-            <p>
-              To facilitate interoperability among user agents and display
-              devices and encourage adoption of the API, the group may provide
-              informative guidelines for implementors, either directly as
-              informative notes within the Presentation API or in a separate
-              non-normative group Note.
-            </p>
-          </dd>
-        </dl>
-        <p> Other non-normative documents may be created for each specification,
-          for example: </p>
-        <ul>
-          <li>Primers </li>
-          <li>Non-normative schemas for language formats </li>
-          <li>Non-normative group notes </li>
-        </ul>
-        <h3> Milestones </h3>
-        <table class="roadmap">
-          <caption> Milestones </caption>
-          <tfoot>
-            <tr>
-              <td colspan="5" rowspan="1"> Note: See changes from this initial schedule on the <a href="https://www.w3.org/2014/secondscreen/">group
-                  home page</a>. </td>
-            </tr>
-          </tfoot>
-          <tbody>
-            <tr>
-              <th rowspan="1" colspan="1"> Specification </th>
-              <th rowspan="1" colspan="1"> <abbr title="First Working Draft">FPWD</abbr>
-              </th>
-              <th rowspan="1" colspan="1"> <abbr title="Candidate Recommendation">CR</abbr>
-              </th>
-              <th rowspan="1" colspan="1"> <abbr title="Proposed Recommendation">PR</abbr>
-              </th>
-              <th rowspan="1" colspan="1"> <abbr title="Recommendation">Rec</abbr>
-              </th>
-            </tr>
-            <tr>
-              <th rowspan="1" colspan="1"> Presentation API </th>
-              <td class="WD1" rowspan="1" colspan="1"> - </td>
-              <td class="CR" rowspan="1" colspan="1"> - </td>
-              <td class="PR" rowspan="1" colspan="1"> <em>Q4 2021</em> </td>
-              <td class="REC" rowspan="1" colspan="1"> <em>Q4 2021</em> </td>
-            </tr>
-            <tr>
-              <th rowspan="1" colspan="1"> Remote Playback API </th>
-              <td class="WD1" rowspan="1" colspan="1"> - </td>
-              <td class="CR" rowspan="1" colspan="1"> - </td>
-              <td class="PR" rowspan="1" colspan="1"> <em>Q4 2020</em> </td>
-              <td class="REC" rowspan="1" colspan="1"> <em>Q4 2020</em> </td>
-            </tr>
-            <tr>
-              <th rowspan="1" colspan="1"> Open Screen Protocol </th>
-              <td class="WD1" rowspan="1" colspan="1"> Q1 2020 </td>
-              <td class="CR" rowspan="1" colspan="1"> Q4 2020 </td>
-              <td class="PR" rowspan="1" colspan="1"> <em>Q2 2021</em> </td>
-              <td class="REC" rowspan="1" colspan="1"> <em>Q2 2021</em> </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <div id="success-criteria">
+              <p>
+                Additional features will be considered for the Presentation API to
+                align it with the work on the Open Screen Protocol, based on
+                implementation experience with that protocol.
+              </p>
+              <p>
+                Additional features will also be considered to improve
+                compatibility with the Remote Playback API and presentation of
+                additional media types that are supported by the Open Screen
+                Protocol.
+              </p>
+              <p>
+                All API changes will be incubated in the Second Screen Community
+                Group before being considered in the Working Group.
+              </p>
+
+            </dd>
+            <dt> <a href="https://www.w3.org/TR/remote-playback/">Remote Playback
+                API</a></dt>
+            <dd>
+              <p> An API that allows a web application to request display of media
+                content on a connected display, with a means to control the remote
+                playback from the initiating page and other authorized pages. </p>
+              <p class="draft-status"> <b>Draft state:</b> <a href="https://www.w3.org/TR/2017/CR-remote-playback-20171019/">
+                  CR</a> / Stable </p>
+              <p class="milestone">
+                <b>Expected completion:</b> Q4 2020 &mdash; The Working Group
+                plans to publish the Remote Playback API as a final Recommendation
+                when the Success Criteria are met.
+              </p>
+              <p>
+                <b>Reference Draft:</b>
+                <a href="https://www.w3.org/TR/2017/CR-remote-playback-20171019/">https://www.w3.org/TR/2017/CR-remote-playback-20171019/</a><br>
+                Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2017Oct/0005.html">Call for Exclusion</a>
+                on 19 October 2017 ended on 18 December 2017<br>
+                Produced under Working Group Charter: https://www.w3.org/2014/secondscreen/charter-2016.html
+              </p>
+              <p>
+                Additional features will be considered for the Remote Playback API
+                to align it with the work on the Open Screen Protocol, based on
+                implementation experience with that protocol.
+              </p>
+              <p>
+                Additional features will also be considered to improve
+                compatibility with the Presentation API and remote playback of
+                additional media types that are supported by the Open Screen
+                Protocol.
+              </p>
+              <p>
+                All API changes will be incubated in the Second Screen Community
+                Group before being considered in the Working Group.
+              </p>
+            </dd>
+            <dt> <a href="https://webscreens.github.io/openscreenprotocol/">Open Screen Protocol</a> </dt>
+            <dd>
+              <p>
+                A suite of network protocols that allow user agents to implement
+                the Presentation API and the Remote Playback API in an
+                interoperable fashion for browsers and presentation displays
+                connected via the same local area network.
+              </p>
+              <p class="draft-status"> <b>Draft state:</b> <a href="https://webscreens.github.io/openscreenprotocol/">
+                  Adopted from the Second Screen Community Group</a></p>
+              <p class="milestone">
+                <b>Expected completion:</b> Q2 2021
+              </p>
+            </dd>
+          </dl>
+          <p> The Working Group may decide to group the API and protocol suite
+            in one or more specifications. </p>
+        </section>
+
+        <section id="other-deliverables">
+          <h3> Other Deliverables </h3>
+          <dl>
+            <dt id="test-suite"> Test suite </dt>
+            <dd>
+              <p>
+                A comprehensive test suite for all features of a specification is
+                necessary to assess the specification's robustness, consistency, and
+                implementability, and to promote interoperability between user
+                agents. Therefore, each specification must have a companion test
+                suite, which should be completed before transition to Candidate
+                Recommendation, and which must be completed with an implementation
+                report before transition to Proposed Recommendation. Additional
+                tests may be added to the test suite at any stage of the
+                Recommendation track, and the maintenance of an implementation
+                report is encouraged.
+              </p>
+              <p>
+                Additionally, this Working Group will improve test automation for
+                the Presentation API and Remote Playback API test suites. This
+                will be done through the adoption of a Testing API, incubated in
+                an appropriate Community Group. The Testing API will also allow
+                developers to use automation to test their own Web applications
+                that make use of the above-mentioned APIs.
+              </p>
+            </dd>
+            <dt> Use cases and requirements </dt>
+            <dd>
+              <p>
+                The Working Group is strongly encouraging the participants to
+                create and maintain a use cases and requirements document for each
+                specification.
+              </p>
+            </dd>
+            <dt> Implementation guidelines </dt>
+            <dd>
+              <p>
+                To facilitate interoperability among user agents and display
+                devices and encourage adoption of the API, the group may provide
+                informative guidelines for implementors, either directly as
+                informative notes within the Presentation API or in a separate
+                non-normative group Note.
+              </p>
+            </dd>
+          </dl>
+          <p> Other non-normative documents may be created for each specification,
+            for example: </p>
+          <ul>
+            <li>Primers </li>
+            <li>Non-normative schemas for language formats </li>
+            <li>Non-normative group notes </li>
+          </ul>
+        </section>
+
+        <section id="timeline">
+          <h3> Timeline </h3>
+          <table class="roadmap">
+            <caption> Milestones </caption>
+            <tfoot>
+              <tr>
+                <td colspan="5" rowspan="1"> Note: See changes from this initial schedule on the <a href="https://www.w3.org/2014/secondscreen/">group
+                    home page</a>. </td>
+              </tr>
+            </tfoot>
+            <tbody>
+              <tr>
+                <th rowspan="1" colspan="1"> Specification </th>
+                <th rowspan="1" colspan="1"> <abbr title="First Working Draft">FPWD</abbr>
+                </th>
+                <th rowspan="1" colspan="1"> <abbr title="Candidate Recommendation">CR</abbr>
+                </th>
+                <th rowspan="1" colspan="1"> <abbr title="Proposed Recommendation">PR</abbr>
+                </th>
+                <th rowspan="1" colspan="1"> <abbr title="Recommendation">Rec</abbr>
+                </th>
+              </tr>
+              <tr>
+                <th rowspan="1" colspan="1"> Presentation API </th>
+                <td class="WD1" rowspan="1" colspan="1"> - </td>
+                <td class="CR" rowspan="1" colspan="1"> - </td>
+                <td class="PR" rowspan="1" colspan="1"> <em>Q4 2021</em> </td>
+                <td class="REC" rowspan="1" colspan="1"> <em>Q4 2021</em> </td>
+              </tr>
+              <tr>
+                <th rowspan="1" colspan="1"> Remote Playback API </th>
+                <td class="WD1" rowspan="1" colspan="1"> - </td>
+                <td class="CR" rowspan="1" colspan="1"> - </td>
+                <td class="PR" rowspan="1" colspan="1"> <em>Q4 2020</em> </td>
+                <td class="REC" rowspan="1" colspan="1"> <em>Q4 2020</em> </td>
+              </tr>
+              <tr>
+                <th rowspan="1" colspan="1"> Open Screen Protocol </th>
+                <td class="WD1" rowspan="1" colspan="1"> Q1 2020 </td>
+                <td class="CR" rowspan="1" colspan="1"> Q4 2020 </td>
+                <td class="PR" rowspan="1" colspan="1"> <em>Q2 2021</em> </td>
+                <td class="REC" rowspan="1" colspan="1"> <em>Q2 2021</em> </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </section>
+
+      <section id="success-criteria">
         <h2> Success Criteria </h2>
-        <p> To advance to <a href="https://www.w3.org/2015/Process-20150901/#RecsCR">Proposed
-            Recommendation</a>, each specification is expected to have two
-          independent implementations of each feature defined in the
-          specification. </p>
+        <p>
+          In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.
+        </p>
         <p> To advance to Proposed Recommendation, interoperability between the
           independent implementations should be demonstrated. Interoperable user
           agents hosting the same Presentation API web application should be
           able to render the same content with the same functionality on
           supported presentation displays that are compatible with the content to
           render. </p>
-        <p> The specifications produced by this Working Group will include
-          security and privacy considerations. Specifically, the user must
+        <p>
+          Each specification should contain separate sections detailing all
+          known security and privacy implications for implementers, Web authors,
+          and end users. Specifically, the user must
           always be in control of privacy-sensitive information that may be
           conveyed through the APIs, such as the visibility or access to
           presentation displays, or the URLs of the web content to be presented.
           Specifications should also avoid unnecessary or severe increases to
           fingerprinting surface, especially for
           <a href="https://www.w3.org/TR/fingerprinting-guidance/#dfn-passive-fingerprinting">passive
-          fingerprinting</a>.</p>
-        <p>
-          This Working Group will follow a <a
-          href="https://www.w3.org/2019/02/testing-policy.html">test
-          as you commit</a> approach to specification development, for
-          specifications in CR or above.
+          fingerprinting</a>.
         </p>
-      </div>
-      <div class="dependencies">
-        <h2 id="coordination"> Dependencies and Liaisons </h2>
-        <h3 id="dependencies"> Dependencies </h3>
+        <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+        <p>Each specification should contain a section on accessibility that
+          describes the benefits and impacts, including ways specification
+          features can be used to address them, and recommendations for
+          maximising accessibility in implementations.
+        </p>
+        <p>
+          To promote interoperability, all changes made to specifications should
+          have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.
+        </p>
+      </section>
+
+      <section id="coordination">
+        <h2> Coordination </h2>
+
         <p> The initial drafts of the Presentation API and of the Open Screen
           Protocol were prepared by the
           <a href="http://www.w3.org/community/webscreens/">Second
@@ -461,194 +532,238 @@
           messaging include Web Messaging and the Web Socket API. </p>
         <p> No external dependencies against the specifications of this Working
           Group have been identified. </p>
-        <h3 id="liaisons"> Liaisons </h3>
-        <p> For all specifications, this Working Group will
-        seek <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal
-        review</a> for accessibility, internationalization, performance,
-        privacy, and security with the relevant Working and Interest Groups, and
-        with the <a title="Technical Architecture Group"
-        href="https://www.w3.org/2001/tag/">TAG</a>. Invitation for review must
-        be issued during each major standards-track document transition,
-        including <a title="First Public Working Draft"
-        href="https://www.w3.org/2017/Process-20170301/#RecsWD">FPWD</a> and at
-        least 3 months before <a title="Candidate Recommendation"
-        href="https://www.w3.org/2017/Process-20170301/#RecsCR">CR</a>, and
-        should be issued when major changes occur in a specification. </p>
-        <p> Additional technical coordination with the following Groups will be
-        made, per
-        the <a href="https://www.w3.org/2017/Process-20170301/#WGCharter">W3C
-        Process Document</a>: </p>
-        <dl>
-          <dt><a href="https://www.w3.org/community/webscreens/" id="sspcg">
-              Second Screen Community Group </a></dt>
-          <dd> This group developed the initial version of the Presentation API
-            and of the Open Screen Protocol, and focuses on enabling
-            interoperability among implementations of
-            the second screen APIs, encouraging implementation of the the APIs
-            by browser vendors and establishing complementary specifications for
-            the APIs.
-          </dd>
-          <dt><a id="wai" href="https://www.w3.org/WAI/"> </a><a href="https://www.w3.org/WAI/APA/">Accessible
-              Platform Architectures (APA) Working Group</a> </dt>
-          <dd> To help ensure deliverables support accessibility requirements,
-            particularly with regard to interoperability with assistive
-            technologies, and inclusion in the deliverable of guidance for
-            implementing the group’s deliverables in ways that support
-            accessibility requirements. </dd>
-          <dt><a href="https://www.w3.org/2011/webtv/"> Media and Entertainment
-          Interest Group</a></dt>
-          <dd> This group provides use cases and requirements for second screen
-            scenarios and thus important input on the deliverables developed by
-            the Second Screen Working Group. </dd>
-          <dt><a href="https://www.w3.org/2011/04/webrtc/"> Web Real-Time
-              Communications Working Group </a></dt>
-          <dd> This group defines relevant or potentially relevant
-            specifications for establishing peer-to-peer communication channels
-            between web applications.
-          </dd>
-        </dl>
-        <h3 id="external-groups"> External Groups </h3>
-        <p> While the Presentation API does not have a direct dependency on any
-          given set of protocols, the following is a tentative list of external
-          bodies the Working Group should collaborate with to develop the Open
-          Screen Protocol and allow the Presentation API and Remote Playback API
-          to be implemented on top of widely deployed attachment methods for
-        connected displays: </p>
-        <dl>
-          <dt><a href="https://www.ietf.org" id="ietf">IETF</a></dt>
-          <dd> The IETF develops network protocols that presentation displays
-            may support, and that form the core of the Open Screen Protocol. The
-            Second Screen Working Group will liaise with relevant groups at IETF
-            to assure proper and secure application of IETF protocols within
-            the Open Screen Protocol. These groups include
-            <a href=
-            "https://datatracker.ietf.org/wg/dnssd/documents/">Extensions for
-            Scalable DNS Service Discovery</a>, <a href=
-            "https://datatracker.ietf.org/wg/quic/documents/">QUIC</a>, <a href=
-            "https://datatracker.ietf.org/wg/tls/documents/">Transport Layer
-            Security</a> (TLS), <a href=
-            "https://datatracker.ietf.org/rg/cfrg/documents/">Crypto Forum Research Group</a>,
-            and <a href="https://datatracker.ietf.org/wg/cbor/">Concise Binary
-            Object Representation Maintenance and Extensions</a>. The Second
-            Screen Working Group will also liaise with IETF to assess whether
-            parts of the Open Screen Protocol apply to broader scenarios than
-            the ones envisioned for the APIs. Those parts may be developed
-            further in the IETF. </dd>
-          <dt><a href="https://openconnectivity.org/">Open Connectivity Foundation</a></dt>
-          <dd> The Open Connectivity Foundation develops home network protocols that presentation
-            displays may support, including the UPnP suite of protocols. </dd>
-          <dt><a href="https://spec.whatwg.org/" id="whatwg">Web Hypertext Application Technology Working Group</a> (WHATWG)</dt>
-          <dd> WHATWG develops the <a href="https://html.spec.whatwg.org/">HTML</a>
-            specification that contains the definition of the
-            <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a>
-            interface that the Remote Playback API specification extends; as
-            well as the <a href="https://html.spec.whatwg.org/#network">Web sockets</a>
-            and the <a href="https://html.spec.whatwg.org/#web-messaging">cross-document
-            messaging</a> interfaces after which the communication channel of the
-            Presentation API is modeled.</dd>
-          <dt><a href="https://www.wi-fi.org/">Wi-Fi Alliance</a></dt>
-          <dd> The Wi-Fi Alliance develops home network protocols that presentation
-            displays may support. </dd>
-        </dl>
-        <div class="participation">
-          <h2 id="participation"> Participation </h2>
-          <p> To be successful, the Second Screen Working Group is expected to
-            have 6 or more active participants for its duration, and to have
-            the participation of industry leaders in fields relevant to the
-            specifications it produces. </p>
-          <p> The Chairs and specification Editors are expected to contribute
-            half a working day per week towards the Working Group. There is no
-            minimum requirement for other Participants. This Working Group will
-            also allocate the necessary resources for building Test Suites for
-            each specification. </p>
-          <p> The group also welcomes non-Members to contribute technical
-            submissions for consideration, with the agreement from each
-            participant to Royalty-Free licensing of those submissions under the
-            W3C Patent Policy. </p>
-        </div>
-        <div class="communication">
-          <h2 id="communication"> Communication </h2>
-          <p> Teleconferences will be conducted on an as-needed basis. </p>
-          <p> This group primarily conducts its technical work on GitHub. The
-            public mailing list
-            <a href="https://lists.w3.org/Archives/Public/public-secondscreen/">public-secondscreen@w3.org</a>
-            is used for calls for consensus. Administrative tasks may be
-            conducted in Member-only communications.
-          </p>
-          <p> Information about the group (deliverables, participants,
-            face-to-face meetings, teleconferences, etc.) is available from the
-            <a href="https://www.w3.org/2014/secondscreen/">Second Screen
-              Working Group</a> home page. </p>
-        </div>
-        <div class="decisions">
-          <h2 id="decisions"> Decision Policy </h2>
-          <p>
-            This group will seek to make decisions through consensus and due
-            process, per the
-            <a href="https://www.w3.org/2017/Process-20170301/#Consensus">W3C
-            Process Document (section 3.3)</a>. Typically, an editor or other
-            participant makes an initial proposal, which is then refined in
-            discussion with members of the group and other reviewers, and
-            consensus emerges with little formal voting being required.
-          </p>
-          <p>
-            However, if a decision is necessary for timely progress, but
-            consensus is not achieved after careful consideration of the range
-            of views presented, the Chairs may call for a group vote, and
-            record a decision along with any objections.
-          </p>
-          <p>
-            To afford asynchronous decisions and organizational deliberation,
-            any resolution (including publication decisions) taken in a
-            face-to-face meeting or teleconference will be considered
-            provisional.
-          </p>
-          <p>
-            A call for consensus (CfC) will be issued for all resolutions (for
-            example, via email and/or web-based survey), with a response period
-            from one week to 10 working days, depending on the chair's
-            evaluation of the group consensus on the issue.
-          </p>
-          <p>
-            If no objections are raised on the mailing list by the end of the
-            response period, the resolution will be considered to have
-            consensus as a resolution of the Working Group.
-          </p>
-          <p>
-            All decisions made by the group should be considered resolved
-            unless and until new information becomes available, or unless
-            reopened at the discretion of the Chairs or the Director.
-          </p>
-          <p>
-            This charter is written in accordance with the
-            <a href="https://www.w3.org/Consortium/Process/policies#Votes">W3C
-            Process Document (Section 3.4, Votes)</a>, and includes no voting
-            procedures beyond what the Process Document requires.
-          </p>
-        </div>
-        <div class="patent">
-          <h2 id="patentpolicy"> Patent Policy </h2>
-          <p> This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C
-              Patent Policy</a> (Version of 15 September 2020). To promote the widest
-            adoption of Web standards, W3C seeks to issue Recommendations that
-            can be implemented, according to this policy, on a Royalty-Free
-            basis. </p>
-          <p> For more information about disclosure obligations for this group,
-            please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C
-              Patent Policy Implementation</a>. </p>
-        </div>
-        <div id="licensing">
-          <h2>Licensing</h2>
-          <p> This Working Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C
-              Software and Document license</a> for all its deliverables. </p>
-        </div>
-        <h2 id="about"> About this Charter </h2>
-        <p> This charter for the Second Screen Working Group has been created
-          according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section
-            5.2</a> of the <a href="https://www.w3.org/Consortium/Process">Process
-            Document</a>. In the event of a conflict between this document or
-          the provisions of any charter and the W3C Process, the W3C Process
-          shall take precedence. </p>
+
+        <p>For all specifications, this Working Group will seek
+          <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
+          accessibility, internationalization, performance, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major standards-track document transition, including
+          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The
+          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
+          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
+          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+
+        <section id="w3c-coordination">
+          <h3> W3C Groups </h3>
+
+          <dl>
+            <dt><a href="https://www.w3.org/community/webscreens/" id="sspcg">
+                Second Screen Community Group </a></dt>
+            <dd> This group developed the initial version of the Presentation API
+              and of the Open Screen Protocol, and focuses on enabling
+              interoperability among implementations of
+              the second screen APIs, encouraging implementation of the the APIs
+              by browser vendors and establishing complementary specifications for
+              the APIs.
+            </dd>
+            <dt><a id="wai" href="https://www.w3.org/WAI/"> </a><a href="https://www.w3.org/WAI/APA/">Accessible
+                Platform Architectures (APA) Working Group</a> </dt>
+            <dd> To help ensure deliverables support accessibility requirements,
+              particularly with regard to interoperability with assistive
+              technologies, and inclusion in the deliverable of guidance for
+              implementing the group’s deliverables in ways that support
+              accessibility requirements. </dd>
+            <dt><a href="https://www.w3.org/2011/webtv/"> Media and Entertainment
+            Interest Group</a></dt>
+            <dd> This group provides use cases and requirements for second screen
+              scenarios and thus important input on the deliverables developed by
+              the Second Screen Working Group. </dd>
+            <dt><a href="https://www.w3.org/2011/04/webrtc/"> Web Real-Time
+                Communications Working Group </a></dt>
+            <dd> This group defines relevant or potentially relevant
+              specifications for establishing peer-to-peer communication channels
+              between web applications.
+            </dd>
+          </dl>
+        </section>
+
+        <section id="external-coordination">
+          <h3> External Organizations </h3>
+          <p> While the Presentation API does not have a direct dependency on any
+            given set of protocols, the following is a tentative list of external
+            bodies the Working Group should collaborate with to develop the Open
+            Screen Protocol and allow the Presentation API and Remote Playback API
+            to be implemented on top of widely deployed attachment methods for
+          connected displays: </p>
+          <dl>
+            <dt><a href="https://www.ietf.org" id="ietf">IETF</a></dt>
+            <dd> The IETF develops network protocols that presentation displays
+              may support, and that form the core of the Open Screen Protocol. The
+              Second Screen Working Group will liaise with relevant groups at IETF
+              to assure proper and secure application of IETF protocols within
+              the Open Screen Protocol. These groups include
+              <a href=
+              "https://datatracker.ietf.org/wg/dnssd/documents/">Extensions for
+              Scalable DNS Service Discovery</a>, <a href=
+              "https://datatracker.ietf.org/wg/quic/documents/">QUIC</a>, <a href=
+              "https://datatracker.ietf.org/wg/tls/documents/">Transport Layer
+              Security</a> (TLS), <a href=
+              "https://datatracker.ietf.org/rg/cfrg/documents/">Crypto Forum Research Group</a>,
+              and <a href="https://datatracker.ietf.org/wg/cbor/">Concise Binary
+              Object Representation Maintenance and Extensions</a>. The Second
+              Screen Working Group will also liaise with IETF to assess whether
+              parts of the Open Screen Protocol apply to broader scenarios than
+              the ones envisioned for the APIs. Those parts may be developed
+              further in the IETF. </dd>
+            <dt><a href="https://openconnectivity.org/">Open Connectivity Foundation</a></dt>
+            <dd> The Open Connectivity Foundation develops home network protocols that presentation
+              displays may support, including the UPnP suite of protocols. </dd>
+            <dt><a href="https://spec.whatwg.org/" id="whatwg">Web Hypertext Application Technology Working Group</a> (WHATWG)</dt>
+            <dd> WHATWG develops the <a href="https://html.spec.whatwg.org/">HTML</a>
+              specification that contains the definition of the
+              <a href="https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a>
+              interface that the Remote Playback API specification extends; as
+              well as the <a href="https://html.spec.whatwg.org/#network">Web sockets</a>
+              and the <a href="https://html.spec.whatwg.org/#web-messaging">cross-document
+              messaging</a> interfaces after which the communication channel of the
+              Presentation API is modeled.</dd>
+            <dt><a href="https://www.wi-fi.org/">Wi-Fi Alliance</a></dt>
+            <dd> The Wi-Fi Alliance develops home network protocols that presentation
+              displays may support. </dd>
+          </dl>
+        </section>
+      </section>
+
+      <section id="participation" class="participation">
+        <h2> Participation </h2>
+        <p> To be successful, the Second Screen Working Group is expected to
+          have 6 or more active participants for its duration, including
+          representatives from the key implementors of this specification, and
+          active Editors and Test Leads for each specification. The Chairs,
+          specification Editors, and Test Leads are expected to contribute half
+          of a working day per week towards the Working Group. There is no
+          minimum requirement for other Participants. </p>
+        <p>
+          The group encourages questions, comments and issues on its document
+          repositories, as described in <a href='#communication'>Communication</a>.
+        </p>
+        <p>
+          The group also welcomes non-Members to contribute technical
+          submissions for consideration upon their agreement to the terms of the
+          <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
+          Policy</a>.
+        </p>
+        <p>Participants in the group are required (by the
+          <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C
+          Process</a>) to follow the W3C <a href="https://www.w3.org/Consortium/cepc/">Code
+          of Ethics and Professional Conduct</a>.</p>
+      </section>
+
+      <section id="communication">
+        <h2> Communication </h2>
+        <p id="public">
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
+          The meetings themselves are not open to public participation, however.
+        </p>
+        <p>
+          Information about the group (including details about deliverables,
+          issues, actions, status, participants, and meetings) will be available
+          from the <a href="https://www.w3.org/2014/secondscreen/">Second Screen
+          Working Group</a> home page.
+        </p>
+        <p>
+          Most Working Group teleconferences will focus on discussion of
+          particular specifications, and will be conducted on an as-needed
+          basis.
+        </p>
+        <p>
+          This group primarily conducts its technical work on
+          <a id="public-github" href="https://github.com/w3c/secondscreen-wg">GitHub
+          issues</a>. The public mailing list
+          <a href="https://lists.w3.org/Archives/Public/public-secondscreen/">public-secondscreen@w3.org</a>
+          is used for calls for consensus.
+        </p>
+        <p>
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+        </p>
+      </section>
+
+      <section id="decisions">
+        <h2> Decision Policy </h2>
+        <p>
+          This group will seek to make decisions through consensus and due
+          process, per the
+          <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C
+          Process Document (section 3.3)</a>. Typically, an editor or other
+          participant makes an initial proposal, which is then refined in
+          discussion with members of the group and other reviewers, and
+          consensus emerges with little formal voting being required.
+        </p>
+        <p>
+          However, if a decision is necessary for timely progress and
+          consensus is not achieved after careful consideration of the range
+          of views presented, the Chairs may call for a group vote and
+          record a decision along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation,
+          any resolution (including publication decisions) taken in a
+          face-to-face meeting or teleconference will be considered
+          provisional.
+        </p>
+        <p>
+          A call for consensus (CfC) will be issued for all resolutions (for
+          example, via email and/or web-based survey), with a response period
+          from one week to 10 working days, depending on the chair's
+          evaluation of the group consensus on the issue.
+        </p>
+        <p>
+          If no objections are raised by the end of the response period, the
+          resolution will be considered to have consensus as a resolution of
+          the Working Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved
+          unless and until new information becomes available, or unless
+          reopened at the discretion of the Chairs or the Director.
+        </p>
+        <p>
+          This charter is written in accordance with the
+          <a href="https://www.w3.org/Consortium/Process/policies#Votes">W3C
+          Process Document (Section 3.4, Votes)</a>, and includes no voting
+          procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+      <section id="patentpolicy">
+        <h2> Patent Policy </h2>
+        <p>
+          This Working Group operates under the
+          <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
+          Policy</a> (Version of 15 September 2020). To promote the widest
+          adoption of Web standards, W3C seeks to issue Recommendations that can
+          be implemented, according to this policy, on a Royalty-Free basis.
+        </p>
+        <p>
+          For more information about disclosure obligations for this group,
+          please see the
+          <a href="https://www.w3.org/groups/wg/secondscreen/ipr">licensing
+          information</a>
+        </p>
+      </section>
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>
+          This Working Group will use the
+          <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C
+          Software and Document license</a> for all its deliverables.
+        </p>
+      </section>
+
+      <section id="about">
+        <h2> About this Charter </h2>
+        <p>
+          This charter for the Second Screen Working Group has been created according to
+          <a href="https://www.w3.org/Consortium/Process/#WG-and-IG">section 5.2</a>
+          of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>.
+          In the event of a conflict between this document or the provisions of
+          any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
         <section id="history">
           <h3> Charter History </h3>
           <p>The following table lists details of all changes from the initial
@@ -752,18 +867,29 @@
             </tbody>
           </table>
         </section>
-        <hr />
-        <p class="copyright"> <a rel="Copyright" href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>©
-          2019 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a>
-          <sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-          <a href="https://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-          <a href="https://www.keio.ac.jp/">Keio</a>, <a href="https://ev.buaa.edu.cn/">Beihang</a>),
-          All Rights Reserved. <abbr title="World Wide Web Consortium">W3C</abbr>
-          <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-          <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
-          and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document
-            use</a> rules apply. </p>
-      </div>
-    </div>
+      </section>
+    </main>
+
+    <hr />
+
+    <footer>
+      <address>
+        <a href="mailto:fd@w3.org">François Daoust</a>
+      </address>
+
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
+        © 2021
+        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (
+        <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="https://www.keio.ac.jp/">Keio</a>,
+        <a href="https://ev.buaa.edu.cn/">Beihang</a>
+        ), All Rights Reserved.
+
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+      </p>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
This updates all "boilerplate" parts of the draft charter to match the latest version of the charter template. The update does not introduce any change to the non boilerplate parts of the charter.

The raw diff is large. The [HTML diff](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2F2020%2F12%2Fsecond-screen-wg-charter.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fsecondscreen-charter%2Ff6ae9526b95e7bec7bfdfdc0e9218ab678e2c1d7%2Findex.html) is easier to review.