### PR TITLE
Use consistent "display" terminology in scope section

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,24 +217,22 @@
         <p> The scope of this Working Group is to also define APIs that allow
           scripts to query the device for information about connected displays
           and to position windows relative to those displays. </p>
-        <p> Operating systems generally allow users to connect multiple screens
+        <p> Operating systems generally allow users to connect multiple displays
           to a single device and arrange them virtually to extend the overall
           visual workspace. A variety of applications use platform tools to
-          place windows in such multi-screen environments, but web application
+          place windows in such multi-displays environments, but web application
           developers are limited by existing APIs, which were generally designed
-          around the use of a single screen. </p>
-        <p> The APIs in scope will allow:
-          <ul>
-            <li>to detect if the computer system has more than one connected
-              screen, </li>
-            <li> to detect when screen properties change across connected
-              screens, </li>
-            <li> request screen information required to facilitates window
-              placement across screens, </li>
-            <li> show elements fullscreen on a specific screen, and place
-              windows on a specific screen. </li>
-          </ul>
-        </p>
+          around the use of a single display. </p>
+        <p> The APIs in scope will allow web applications to: </p>
+        <ul>
+          <li> detect if the device has more than one connected display, </li>
+          <li> detect when connected displays are added, removed, or
+          reconfigured, </li>
+          <li> request display information required to facilitate window
+          placement across displays, </li>
+          <li> show elements fullscreen on a specific display, and place
+          windows on a specific display. </li>
+        </ul>
         <p> Members of the Working Group should review other Working Groups'
           deliverables that are identified as being relevant to the Working
           Group's mission. </p>

--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
         <p> Operating systems generally allow users to connect multiple displays
           to a single device and arrange them virtually to extend the overall
           visual workspace. A variety of applications use platform tools to
-          place windows in such multi-displays environments, but web application
+          place windows in such multi-display environments, but web application
           developers are limited by existing APIs, which were generally designed
           around the use of a single display. </p>
         <p> The APIs in scope will allow web applications to: </p>


### PR DESCRIPTION
The text that puts the multi-window placement API in scope of the group used the notion of "screen" whereas the rest of the text uses "display".