### PR TITLE
Add Matter's CSA in external organizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -845,8 +845,9 @@
               devices, mobile app and cloud services. The Second Screen Working
               Group will evaluate features of Matter such as IP-based networking
               technologies for discovery, authentication, transport and media
-              casting. The Working Group will discuss updates to the Open Screen
-              Protocol to align with or reuse these features where appropriate.
+              streaming. The Working Group will discuss updates to the Open
+              Screen Protocol to align with or reuse these features where
+              appropriate.
             </dd>
             <dt>
               <a href="https://www.ietf.org" id="ietf">IETF</a>

--- a/index.html
+++ b/index.html
@@ -835,6 +835,20 @@
           </p>
           <dl>
             <dt>
+              <a href="https://csa-iot.org/" id="csa">Connectivity Standards
+              Alliance</a>
+            </dt>
+            <dd>
+              The Connectivity Standards Alliance (CSA) develops <a href=
+              "https://buildwithmatter.com/">Matter</a>, an industry–unifying
+              standard for reliable and secure connectivity across smart home
+              devices, mobile app and cloud services. The Second Screen Working
+              Group will evaluate features of Matter such as IP-based networking
+              technologies for discovery, authentication, transport and media
+              casting. The Working Group will discuss updates to the Open Screen
+              Protocol to align with or reuse these features where appropriate.
+            </dd>
+            <dt>
               <a href="https://www.ietf.org" id="ietf">IETF</a>
             </dt>
             <dd>


### PR DESCRIPTION
The Connectivity Standards Alliance (formerly Zigbee Alliance) develops Matter, which may have some overlap with the Open Screen Protocol.