### PR TITLE
Rename remaining occurrences of Multi-Screen Window Placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,8 +878,8 @@
               This group maintains the <a href="https://drafts.csswg.org/cssom-view/">CSSOM View
               Module</a> which defines extensions to the <a href=
               "https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">Window
-              interface</a> that expose screen information to web applications. Multi-Screen Window
-              Placement proposes new extensions to this interface.
+              interface</a> that expose screen information to web applications. Window Management
+              proposes new extensions to this interface.
             </dd>
           </dl>
         </section>
@@ -936,8 +936,7 @@
               "https://html.spec.whatwg.org/#htmlmediaelement"><code>HTMLMediaElement</code></a>
               interface that the Remote Playback API specification extends. This group also
               maintains the <a href="https://fullscreen.spec.whatwg.org/">Fullscreen API</a>
-              specification; Multi-Screen Window Placement proposes an extension to the Fullscreen
-              API.
+              specification; Window Management proposes an extension to the Fullscreen API.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
Per feedback in:
https://lists.w3.org/Archives/Public/public-secondscreen/2024Feb/0001.html

This updates a couple of references to "Multi-Screen Window Placement" to "Window Management".

Sections that talk about the Community Group still use the former title because the spec rename occurred after transition to the Working Group.