### PR TITLE
Add security considerations requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -759,8 +759,9 @@
           APIs, such as the visibility or access to presentation displays, or the URLs of the web
           content to be presented. Specifications should minimize and mitigate their <a href=
           "https://www.w3.org/TR/fingerprinting-guidance/#dfn-fingerprinting-surface">fingerprinting
-          surfaces</a>. Security considerations must also include a threat model with threats,
-          attacks, mitigations and residual risks.
+          surfaces</a>. For specifications that enable access to third party systems, security
+          considerations must also include a threat model with threats, attacks, mitigations and
+          residual risks.
         </p>
         <p>
           Each specification should contain a section on accessibility that describes the benefits

--- a/index.html
+++ b/index.html
@@ -759,7 +759,8 @@
           APIs, such as the visibility or access to presentation displays, or the URLs of the web
           content to be presented. Specifications should minimize and mitigate their <a href=
           "https://www.w3.org/TR/fingerprinting-guidance/#dfn-fingerprinting-surface">fingerprinting
-          surfaces</a>.
+          surfaces</a>. Security considerations must also include a threat model with threats,
+          attacks, mitigations and residual risks.
         </p>
         <p>
           Each specification should contain a section on accessibility that describes the benefits


### PR DESCRIPTION
Adds a sentence to note an additional requirement to include a threat model with threats, attacks, mitigations and residual risks, as requested by horizontal review: https://github.com/w3c/strategy/issues/444#issuecomment-1984856326