### PR TITLE
Clarify scope of control protocol in OSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -551,10 +551,11 @@
                 To allow browsers to support more solutions for finding, connecting, and
                 authenticating presentation displays (including solutions based on <a href=
                 "https://csa-iot.org/all-solutions/matter/">Matter</a>), as well as to allow reuse
-                of the control protocol in other contexts (e.g., WebTransport or
-                <code>RTCDataChannel</code>), the Working Group plans to split the Open Screen
-                Protocol specification during this charter period to separate discovery and
-                authentication from the actual control protocol.
+                of the control protocol (the part of the Open Screen Protocol that defines the
+                messages required to implement the APIs developed by this Working Group) in other
+                contexts (e.g., WebTransport or <code>RTCDataChannel</code>), the Working Group
+                plans to split the Open Screen Protocol specification during this charter period to
+                separate discovery and authentication from the actual control protocol.
               </p>
             </dd>
           </dl>


### PR DESCRIPTION
Via https://github.com/w3c/strategy/issues/444#issuecomment-2017745456

Goal is to clarify that the control protocol targets messages requiresd to implement the APIs, and not e.g., all of Matter. Note the Out of scope section is already clear that protocols "not required to implement the APIs developed by this Working Group" are out of scope.